### PR TITLE
Impl log collection opt

### DIFF
--- a/q2_autopepsirf/actions/diffEnrich.py
+++ b/q2_autopepsirf/actions/diffEnrich.py
@@ -4,11 +4,13 @@ from q2_pepsirf.format_types import(
     PepsirfInfoSumOfProbesFmt, PepsirfInfoSNPNFormat,
     PepsirfContingencyTSVFormat, ZscoreNanFormat, EnrichedPeptideDirFmt
 )
+from subprocess import run
 
 import csv
 import os
 import pandas as pd
 import qiime2
+
 
 # Name: diffenrich
 # Process: automatically runs through q2-ps-plot modules and q2-pepsirf modules
@@ -38,6 +40,7 @@ def diffEnrich(
         exact_cs_thresh="20",
         exact_zenrich_thresh=None,
         pepsirf_tsv_dir="./",
+        log_dir="./logs",
         tsv_base_str=None,
         step_z_thresh=5,
         upper_z_thresh=30,
@@ -304,6 +307,13 @@ def diffEnrich(
         pepsirf_binary=pepsirf_binary
     )
 
+    # will be wrapped in a utils function
+    # check for there is not a directory for logs already
+    if not os.path.isdir(log_dir):
+        os.mkdir(log_dir)
+    # collect log files
+    run((f"mv *.log ./{log_dir}").split(), shell=True, check=True)
+    
     # return all files created
     return (
         col_sum, diff, diff_ratio, zscore_out, nan_out, sample_names,

--- a/q2_autopepsirf/actions/diffEnrich.py
+++ b/q2_autopepsirf/actions/diffEnrich.py
@@ -306,13 +306,6 @@ def diffEnrich(
         exact_cs_thresh=exact_cs_thresh,
         pepsirf_binary=pepsirf_binary
     )
-
-    # will be wrapped in a utils function
-    # check for there is not a directory for logs already
-    if not os.path.isdir(log_dir):
-        os.mkdir(log_dir)
-    # collect log files
-    run((f"mv *.log ./{log_dir}").split(), shell=True, check=True)
     
     # return all files created
     return (

--- a/q2_autopepsirf/actions/diffEnrich.py
+++ b/q2_autopepsirf/actions/diffEnrich.py
@@ -40,7 +40,7 @@ def diffEnrich(
         exact_cs_thresh="20",
         exact_zenrich_thresh=None,
         pepsirf_tsv_dir="./",
-        log_dir="./logs",
+        pepsirf_logs_dir="./logs",
         tsv_base_str=None,
         step_z_thresh=5,
         upper_z_thresh=30,

--- a/q2_autopepsirf/actions/diffEnrich.py
+++ b/q2_autopepsirf/actions/diffEnrich.py
@@ -10,6 +10,7 @@ import csv
 import os
 import pandas as pd
 import qiime2
+from q2_autopepsirf.utils import collect_logs
 
 
 # Name: diffenrich
@@ -306,6 +307,8 @@ def diffEnrich(
         exact_cs_thresh=exact_cs_thresh,
         pepsirf_binary=pepsirf_binary
     )
+
+    collect_logs(pepsirf_logs_dir)
     
     # return all files created
     return (

--- a/q2_autopepsirf/actions/diffEnrich_deconv.py
+++ b/q2_autopepsirf/actions/diffEnrich_deconv.py
@@ -27,6 +27,7 @@ def diffEnrich_deconv(
         exact_cs_thresh="20",
         exact_zenrich_thresh=None,
         pepsirf_tsv_dir="./",
+        pepsirf_logs_dir="./logs",
         tsv_base_str=None,
         step_z_thresh=5,
         upper_z_thresh=30,

--- a/q2_autopepsirf/actions/diffEnrich_deconv.py
+++ b/q2_autopepsirf/actions/diffEnrich_deconv.py
@@ -5,6 +5,7 @@ from q2_pepsirf.format_types import (
 )
 
 import os
+from q2_autopepsirf.utils import collect_logs
 
 def diffEnrich_deconv(
         ctx,
@@ -63,6 +64,7 @@ def diffEnrich_deconv(
         exact_cs_thresh=exact_cs_thresh,
         exact_zenrich_thresh=exact_zenrich_thresh,
         pepsirf_tsv_dir=pepsirf_tsv_dir,
+        pepsirf_logs_dir=pepsirf_logs_dir,
         tsv_base_str=tsv_base_str,
         step_z_thresh=step_z_thresh,
         upper_z_thresh=upper_z_thresh,
@@ -93,6 +95,8 @@ def diffEnrich_deconv(
         deconv_base = "%s_deconv_dir.tsv" % (tsv_base_str)
         deconv_tsv = dir_out.view(PepsirfDeconvBatchDirFmt)
         deconv_tsv.save(os.path.join(pepsirf_tsv_dir, deconv_base), ext=".tsv")    
+
+    collect_logs(pepsirf_logs_dir)
 
     return (
         dir_out, score_per_round, map_dir, col_sum, diff, diff_ratio, 

--- a/q2_autopepsirf/actions/diffEnrich_deconv_tsv.py
+++ b/q2_autopepsirf/actions/diffEnrich_deconv_tsv.py
@@ -27,6 +27,7 @@ def diffEnrich_deconv_tsv(
         exact_cs_thresh="20",
         exact_zenrich_thresh=None,
         pepsirf_tsv_dir="./",
+        pepsirf_logs_dir="./logs",
         tsv_base_str=None,
         step_z_thresh=5,
         upper_z_thresh=30,

--- a/q2_autopepsirf/actions/diffEnrich_deconv_tsv.py
+++ b/q2_autopepsirf/actions/diffEnrich_deconv_tsv.py
@@ -115,6 +115,7 @@ def diffEnrich_deconv_tsv(
         exact_cs_thresh=exact_cs_thresh,
         exact_zenrich_thresh=exact_zenrich_thresh,
         pepsirf_tsv_dir=pepsirf_tsv_dir,
+        pepsirf_logs_dir=pepsirf_logs_dir,
         tsv_base_str=tsv_base_str,
         step_z_thresh=step_z_thresh,
         upper_z_thresh=upper_z_thresh,

--- a/q2_autopepsirf/actions/diffEnrich_tsv.py
+++ b/q2_autopepsirf/actions/diffEnrich_tsv.py
@@ -38,6 +38,7 @@ def diffEnrich_tsv(
         exact_cs_thresh="20",
         exact_zenrich_thresh=None,
         pepsirf_tsv_dir="./",
+        pepsirf_logs_dir="./logs",
         tsv_base_str=None,
         step_z_thresh=5,
         upper_z_thresh=30,

--- a/q2_autopepsirf/actions/diffEnrich_tsv.py
+++ b/q2_autopepsirf/actions/diffEnrich_tsv.py
@@ -105,6 +105,7 @@ def diffEnrich_tsv(
         exact_cs_thresh=exact_cs_thresh,
         exact_zenrich_thresh=exact_zenrich_thresh,
         pepsirf_tsv_dir=pepsirf_tsv_dir,
+        pepsirf_logs_dir=pepsirf_logs_dir,
         tsv_base_str=tsv_base_str,
         step_z_thresh=step_z_thresh,
         upper_z_thresh=upper_z_thresh,

--- a/q2_autopepsirf/plugin_setup.py
+++ b/q2_autopepsirf/plugin_setup.py
@@ -98,7 +98,7 @@ shared_parameter_description = {
         " source_samples file and png boxplot outputs will always be put"
         " within this directory.",
     "pepsirf_logs_dir": "Path to a directory which PepSIRF log files will be"
-        " collected."
+        " collected.",
     "tsv_base_str": "The base name for the output tsv files excluding ay"
         " extensions, typcally the raw data filename (EX: --p-tsv-base-str"
         " raw_data). Must also provide pepsirf-tsv-dir, if pepsirf-tsv-dir"

--- a/q2_autopepsirf/plugin_setup.py
+++ b/q2_autopepsirf/plugin_setup.py
@@ -60,6 +60,7 @@ shared_parameters = {
     "upper_z_thresh": Int % Range(2, None),
     "lower_z_thresh": Int % Range(1, None),
     "pepsirf_tsv_dir": Str,
+    "pepsirf_logs_dir": Str,
     "tsv_base_str": Str,
     "hdi": Float % Range(0.0, 1.0),
     "infer_pairs_source": Bool,
@@ -96,6 +97,8 @@ shared_parameter_description = {
         " tsv-base-str for output of tsv verison of qza files. The"
         " source_samples file and png boxplot outputs will always be put"
         " within this directory.",
+    "pepsirf_logs_dir": "Path to a directory which PepSIRF log files will be"
+        " collected."
     "tsv_base_str": "The base name for the output tsv files excluding ay"
         " extensions, typcally the raw data filename (EX: --p-tsv-base-str"
         " raw_data). Must also provide pepsirf-tsv-dir, if pepsirf-tsv-dir"
@@ -273,4 +276,3 @@ plugin.pipelines.register_function(
         " that are used to determine enriched peptides and"
         " **ADD DECONV DESCRIPTION**"
 )
-

--- a/q2_autopepsirf/utils.py
+++ b/q2_autopepsirf/utils.py
@@ -1,5 +1,6 @@
 import os
-import subprocess
+import glob
+import shutil
 
 
 def collect_logs(path):
@@ -8,4 +9,7 @@ def collect_logs(path):
     if not os.path.isdir(path):
         os.mkdir(path)
     # collect log files
-    subprocess.run((f"mv *.log {path}").split(), shell=False, check=True)
+    files = glob.glob("*.log", recursive=True)
+    print(f"Moving {files} into {path}")
+    for file in files:
+        shutil.move(file, path)

--- a/q2_autopepsirf/utils.py
+++ b/q2_autopepsirf/utils.py
@@ -1,0 +1,11 @@
+import os
+from subprocess import run
+
+
+def collect_logs(path):
+    # collect pepsirf logs into a directory at `path`
+    # check for there is not a directory for logs already
+    if not os.path.isdir(log_dir):
+        os.mkdir(log_dir)
+    # collect log files
+    run((f"mv *.log ./{log_dir}").split(), shell=True, check=True)

--- a/q2_autopepsirf/utils.py
+++ b/q2_autopepsirf/utils.py
@@ -10,6 +10,5 @@ def collect_logs(path):
         os.mkdir(path)
     # collect log files
     files = glob.glob("*.log", recursive=True)
-    print(f"Moving {files} into {path}")
     for file in files:
         shutil.move(file, path)

--- a/q2_autopepsirf/utils.py
+++ b/q2_autopepsirf/utils.py
@@ -1,11 +1,11 @@
 import os
-from subprocess import run
+import subprocess
 
 
 def collect_logs(path):
     # collect pepsirf logs into a directory at `path`
     # check for there is not a directory for logs already
-    if not os.path.isdir(log_dir):
-        os.mkdir(log_dir)
+    if not os.path.isdir(path):
+        os.mkdir(path)
     # collect log files
-    run((f"mv *.log ./{log_dir}").split(), shell=True, check=True)
+    subprocess.run((f"mv *.log ./{path}").split(), shell=True, check=True)

--- a/q2_autopepsirf/utils.py
+++ b/q2_autopepsirf/utils.py
@@ -8,4 +8,4 @@ def collect_logs(path):
     if not os.path.isdir(path):
         os.mkdir(path)
     # collect log files
-    subprocess.run((f"mv *.log ./{path}").split(), shell=True, check=True)
+    subprocess.run((f"mv *.log {path}").split(), shell=True, check=True)

--- a/q2_autopepsirf/utils.py
+++ b/q2_autopepsirf/utils.py
@@ -8,4 +8,4 @@ def collect_logs(path):
     if not os.path.isdir(path):
         os.mkdir(path)
     # collect log files
-    subprocess.run((f"mv *.log {path}").split(), shell=True, check=True)
+    subprocess.run((f"mv *.log {path}").split(), shell=False, check=True)


### PR DESCRIPTION
Adds a new option to specify a directory into which autopepsirf will collect PepSIRF's log files. The default directory name is "logs". This should improve the user experience since *.log files will not be scattered after running autopepsirf.